### PR TITLE
Fix provider configuration

### DIFF
--- a/src/provider-datadog.tf
+++ b/src/provider-datadog.tf
@@ -1,5 +1,5 @@
 module "datadog_configuration" {
-  source  = "../datadog-configuration/modules/datadog_keys"
+  source  = "github.com/cloudposse-terraform-components/aws-datadog-credentials//src/modules/datadog_keys?ref=tags/v1.535.2"
   enabled = true
   context = module.this.context
 }


### PR DESCRIPTION
## what
* Replace relative path for datadog creds module with git reference to the component

## why
* After we split monorepo we can not use relative paths for component references



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Datadog configuration to use a remote, versioned module source for improved reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->