### PR TITLE
chore(deps): restrict helm provider version to ~ 2.0.0

### DIFF
--- a/src/versions.tf
+++ b/src/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     template = {
       source  = "hashicorp/template"
-      version = "~> 2.0"
+      version = ">= 2.0"
     }
     local = {
       source  = "hashicorp/local"
@@ -16,7 +16,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.3.0"
+      version = "~> 2.3.0"
     }
     datadog = {
       source  = "datadog/datadog"

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     template = {
       source  = "hashicorp/template"
-      version = ">= 2.0"
+      version = "~> 2.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.3.0"
+      version = ">= 2.3.0, < 3.0.0"
     }
     datadog = {
       source  = "datadog/datadog"


### PR DESCRIPTION
This pull request includes a version constraint update for the Helm provider in the Terraform configuration file `src/versions.tf`. The change ensures compatibility with versions up to but not including 3.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the version constraint for the "template" provider to improve compatibility control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->