### PR TITLE
fix: Remove deprecated Terraform syntax

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -3,7 +3,7 @@ locals {
 
   # https://docs.datadoghq.com/synthetics/private_locations/configuration
   # docker run --rm datadog/synthetics-private-location-worker --help
-  private_location_config = jsondecode(join("", datadog_synthetics_private_location.this.*.config))
+  private_location_config = jsondecode(join("", datadog_synthetics_private_location.this[*].config))
 }
 
 resource "datadog_synthetics_private_location" "this" {


### PR DESCRIPTION
## Why

Deprecated HCL syntax triggers linting warnings and will eventually be removed in future Terraform versions. Cleaning these up improves code quality, maintainability, and ensures forward compatibility.

## What

Automated fixes applied via `tflint --fix` with the following rules enabled:

| Rule | Description | Example |
|------|-------------|---------|
| `terraform_deprecated_interpolation` | Remove unnecessary interpolation wrappers | `"${var.foo}"` → `var.foo` |
| `terraform_deprecated_index` | Replace legacy dot-index syntax | `list.0` → `list[0]` |
| `terraform_deprecated_lookup` | Replace deprecated `lookup()` calls | `lookup(map, key)` → `map[key]` |

## References

- [tflint terraform_deprecated_interpolation](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_interpolation.md)
- [tflint terraform_deprecated_index](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_index.md)
- [tflint terraform_deprecated_lookup](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_lookup.md)
- [Terraform: References to Named Values](https://developer.hashicorp.com/terraform/language/expressions/references)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal aggregation syntax for private location configuration to improve code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse-terraform-components/aws-datadog-synthetics-private-location/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->